### PR TITLE
Fix risk calculator hashing bug

### DIFF
--- a/src/utils/riskCalculator.ts
+++ b/src/utils/riskCalculator.ts
@@ -60,7 +60,8 @@ export class RiskCalculator {
     for (let i = 0; i < seed.length; i++) {
       const char = seed.charCodeAt(i);
       hash = ((hash << 5) - hash) + char;
-      hash = hash & hash; // Convert to 32-bit integer
+      // Force hash to 32-bit integer
+      hash |= 0;
     }
     
     // Normalize to 0-1 range, then scale to min-max


### PR DESCRIPTION
## Summary
- ensure generated hash values properly coerce to 32‑bit integers in `RiskCalculator`

## Testing
- `npm run build` *(fails: Cannot find name 'google' in many files)*

------
https://chatgpt.com/codex/tasks/task_e_68672a8c338c8323a5aa6aa85d720349