### PR TITLE
Disable editing on analysis map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,8 @@
-Acadia_Transit_Sentinel
+# Acadia Transit Sentinel
+
+This project provides advanced route analysis tailored for large vehicles. Use
+the **Route Planning** tab to set your origin, destination, and any stops. Drag
+the markers on this planning map to fine‑tune exact locations. Once satisfied,
+analyze the route to view the three safest options. The **Route Analysis** view
+now shows results on a read‑only map so adjustments stay focused on the planning
+stage.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -475,9 +475,9 @@ function App() {
                     selectedRouteId={selectedRouteId}
                     vehicle={vehicle}
                     onRouteSelect={setSelectedRouteId}
-                    onRouteUpdate={handleRouteUpdate}
                     className="h-[600px] rounded-lg shadow-md"
                     initialCenter={initialCenter}
+                    allowEditing={false}
                   />
                 ) : (
                   <div className="bg-white dark:bg-gray-800 rounded-lg shadow-md p-6 border border-gray-100 dark:border-gray-700 transition-colors duration-300 h-[600px] flex items-center justify-center">


### PR DESCRIPTION
## Summary
- keep editing functionality on planning map only
- add `allowEditing` prop to `MultiRouteMapComponent`
- render analysis map in read-only mode and update docs

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: numerous TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_686751449ee483238d8374d5c9743b1f