### PR TITLE
Improve planning map marker handling

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -50,6 +50,8 @@ function App() {
   const [planningDestination, setPlanningDestination] = useState('');
   const [planningStops, setPlanningStops] = useState<StopLocation[]>([]);
   const [planningMapReady, setPlanningMapReady] = useState(false);
+  const [planningOriginCoords, setPlanningOriginCoords] = useState<{ lat: number; lng: number } | undefined>(undefined);
+  const [planningDestinationCoords, setPlanningDestinationCoords] = useState<{ lat: number; lng: number } | undefined>(undefined);
 
   const selectedRoute = routes.find(route => route.id === selectedRouteId);
 
@@ -100,15 +102,25 @@ function App() {
     setPlanningDestination(destination);
     setPlanningStops(stops || []);
     setPlanningMapReady(true);
+    setPlanningOriginCoords(undefined);
+    setPlanningDestinationCoords(undefined);
     if (loopEnabled !== undefined) {
       setIsLoop(loopEnabled);
     }
   };
 
-  const handlePlanningMapUpdate = (origin: string, destination: string, stops: StopLocation[]) => {
+  const handlePlanningMapUpdate = (
+    origin: string,
+    destination: string,
+    stops: StopLocation[],
+    originCoords?: { lat: number; lng: number },
+    destinationCoords?: { lat: number; lng: number }
+  ) => {
     setPlanningOrigin(origin);
     setPlanningDestination(destination);
     setPlanningStops(stops || []);
+    if (originCoords) setPlanningOriginCoords(originCoords);
+    if (destinationCoords) setPlanningDestinationCoords(destinationCoords);
   };
 
   const handleAnalyzeRoutes = async () => {
@@ -406,6 +418,8 @@ function App() {
                   onMapUpdate={handlePlanningMapUpdate}
                   className="h-[600px] rounded-lg shadow-md"
                   initialCenter={initialCenter}
+                  originCoords={planningOriginCoords}
+                  destinationCoords={planningDestinationCoords}
                   isLoop={isLoop}
                 />
 

--- a/src/components/StopLocationsManager.tsx
+++ b/src/components/StopLocationsManager.tsx
@@ -24,7 +24,9 @@ export const StopLocationsManager: React.FC<StopLocationsManagerProps> = ({
       id: `stop-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`,
       address: '',
       order: stops.length,
-      estimatedStopTime: 15
+      estimatedStopTime: 15,
+      lat: undefined,
+      lng: undefined,
     };
     onStopsChange([...stops, newStop]);
   };
@@ -218,7 +220,13 @@ export const StopLocationsManager: React.FC<StopLocationsManagerProps> = ({
                         onChange={(address) => updateStop(stop.id, { address })}
                         placeholder="Enter stop address"
                         disabled={disabled}
-                        onLocationSelect={(location) => updateStop(stop.id, { address: location.address })}
+                        onLocationSelect={(location) =>
+                          updateStop(stop.id, {
+                            address: location.address,
+                            lat: location.lat,
+                            lng: location.lng,
+                          })
+                        }
                       />
                     </div>
                     

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -111,6 +111,8 @@ export interface StopLocation {
   id: string;
   address: string;
   name?: string;
+  lat?: number;
+  lng?: number;
   order: number;
   estimatedStopTime?: number; // minutes
 }


### PR DESCRIPTION
## Summary
- persist lat/lng in `StopLocation`
- keep planning coordinates when dragging markers
- update map with provided coordinates to avoid marker snapping
- ensure new stops start undefined until user specifies location

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68675660650c83238cbf8b19946801de