### PR TITLE
Disable route preview on planning map

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Acadia Transit Sentinel
 
 This project provides advanced route analysis tailored for large vehicles. Use
-the **Route Planning** tab to set your origin, destination, and any stops. Drag
-the markers on this planning map to fine‑tune exact locations. Once satisfied,
-analyze the route to view the three safest options. The **Route Analysis** view
-now shows results on a read‑only map so adjustments stay focused on the planning
-stage.
+the **Route Planning** tab to drop markers for your origin, destination, and
+any stops. Only the pins appear on this map so you can position them precisely.
+Click **Analyze Routes** to see the three safest options. The **Route Analysis**
+view then displays those routes on a read‑only map, keeping adjustments focused
+on the planning stage.


### PR DESCRIPTION
## Summary
- allow `PlanningMapComponent` to toggle route preview
- show only marker pins while planning
- update README to describe drop‑pin workflow

## Testing
- `npm run lint` *(fails: many existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68675c52d7fc832392e4c0e9831493fe