### PR TITLE
Improve map centering and bus routing

### DIFF
--- a/src/components/PlanningMapComponent.tsx
+++ b/src/components/PlanningMapComponent.tsx
@@ -218,6 +218,12 @@ export const PlanningMapComponent: React.FC<PlanningMapComponentProps> = ({
           }
 
           if (stopLocation) {
+            const distanceToOrigin = googleMapsService.calculateDistance(stopLocation, originLocation);
+            const distanceToDestination = googleMapsService.calculateDistance(stopLocation, destinationLocation);
+            if (distanceToOrigin < 20 || distanceToDestination < 20) {
+              stopLocation = new google.maps.LatLng(stopLocation.lat() + 0.00015, stopLocation.lng() + 0.00015);
+            }
+
             const stopMarker = new google.maps.Marker({
               position: stopLocation,
               map: map,
@@ -241,6 +247,17 @@ export const PlanningMapComponent: React.FC<PlanningMapComponentProps> = ({
         }
       }
       setStopMarkers(newStopMarkers);
+
+      const bounds = new google.maps.LatLngBounds();
+      bounds.extend(originLocation);
+      bounds.extend(destinationLocation);
+      newStopMarkers.forEach(m => {
+        const pos = m.getPosition();
+        if (pos) bounds.extend(pos);
+      });
+      if (!bounds.isEmpty()) {
+        map.fitBounds(bounds);
+      }
 
       // If it's a loop route, add a visual indicator
       if (isLoop) {

--- a/src/services/googleMapsService.ts
+++ b/src/services/googleMapsService.ts
@@ -390,7 +390,8 @@ private filterRoutesByConstraints(routes: google.maps.DirectionsRoute[], constra
     for (const leg of route.legs) {
       for (const step of leg.steps) {
         const instr = step.instructions.toLowerCase();
-        if (constraints.avoidUTurns && instr.includes('u-turn')) return false;
+        const hasUTurn = instr.includes('u-turn') || instr.includes('u turn') || instr.includes('turn around');
+        if (constraints.avoidUTurns && hasUTurn) return false;
         if (constraints.avoidSharpTurns && instr.includes('sharp turn')) return false;
         if (constraints.avoidResidential && instr.includes('residential')) return false;
       }


### PR DESCRIPTION
## Summary
- adjust stop marker placement in planning map
- fit map bounds after markers added
- detect more U-turn variations in route filtering

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: many TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68676059be048323ae1bd78922178544