### PR TITLE
Fix planning map preview and limit route results

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 This project provides advanced route analysis tailored for large vehicles. Use
 the **Route Planning** tab to drop markers for your origin, destination, and
 any stops. Only the pins appear on this map so you can position them precisely.
-Click **Analyze Routes** to see the three safest options. The **Route Analysis**
-view then displays those routes on a read‑only map, keeping adjustments focused
-on the planning stage.
+No route lines are drawn during planning so the map stays uncluttered.
+Once the locations are set, click **Analyze Routes** to generate results.
+The **Route Analysis** view displays the three safest routes ranked by overall
+risk score on a read‑only map, keeping adjustments focused on the planning
+stage.

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -158,6 +158,7 @@ function App() {
           return analyzed;
         });
         analyzedRoutes.sort((a, b) => a.overallRisk - b.overallRisk);
+        analyzedRoutes = analyzedRoutes.slice(0, 3);
       }
       const largeVehicleAnalysisData = generateLargeVehicleAnalysis(vehicle, analyzedRoutes);
       setRoutes(analyzedRoutes);
@@ -284,6 +285,7 @@ function App() {
         return analyzed;
       });
       analyzedRoutes.sort((a, b) => a.overallRisk - b.overallRisk);
+      analyzedRoutes = analyzedRoutes.slice(0, 3);
       const result = {
         routes: analyzedRoutes,
         recommendedRouteId: analyzedRoutes[0]?.id || '',
@@ -421,6 +423,7 @@ function App() {
                   originCoords={planningOriginCoords}
                   destinationCoords={planningDestinationCoords}
                   isLoop={isLoop}
+                  showRoute={false}
                 />
 
                 {planningMapReady && (

--- a/src/components/PlanningMapComponent.tsx
+++ b/src/components/PlanningMapComponent.tsx
@@ -59,6 +59,19 @@ export const PlanningMapComponent: React.FC<PlanningMapComponentProps> = ({
     }
   }, [map, isReady, origin, destination, stops, isLoop]);
 
+  // Clear any existing route preview when disabled
+  useEffect(() => {
+    if (!showRoute) {
+      if (directionsRenderer) {
+        directionsRenderer.setDirections({ routes: [] } as any);
+      }
+      if (routePolyline) {
+        routePolyline.setMap(null);
+        setRoutePolyline(null);
+      }
+    }
+  }, [showRoute, directionsRenderer, routePolyline]);
+
   const initializeMap = useCallback(async () => {
     if (!mapRef.current) {
       setError('Map container not found.');


### PR DESCRIPTION
## Summary
- hide any route preview lines when the planning map is used
- limit analysis to the top three safest routes
- document workflow in README

## Testing
- `npm run lint` *(fails: cannot find package '@eslint/js')*
- `npm run build` *(fails: cannot find namespace 'google')*

------
https://chatgpt.com/codex/tasks/task_e_686762d610448323a4b6e15f4d0b9d03