### PR TITLE
Fix U‑turn detection for large vehicles

### DIFF
--- a/src/services/googleMapsService.ts
+++ b/src/services/googleMapsService.ts
@@ -390,7 +390,12 @@ private filterRoutesByConstraints(routes: google.maps.DirectionsRoute[], constra
     for (const leg of route.legs) {
       for (const step of leg.steps) {
         const instr = step.instructions.toLowerCase();
-        const hasUTurn = instr.includes('u-turn') || instr.includes('u turn') || instr.includes('turn around');
+        const maneuver = (step as any).maneuver?.toLowerCase() || '';
+        const hasUTurn =
+          instr.includes('u-turn') ||
+          instr.includes('u turn') ||
+          instr.includes('turn around') ||
+          maneuver.includes('uturn');
         if (constraints.avoidUTurns && hasUTurn) return false;
         if (constraints.avoidSharpTurns && instr.includes('sharp turn')) return false;
         if (constraints.avoidResidential && instr.includes('residential')) return false;


### PR DESCRIPTION
## Summary
- detect U‑turns using step `maneuver` field in `googleMapsService`

## Testing
- `npm run lint` *(fails: several eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_6868509261e88323bce559fc3e89c06a