### PR TITLE
Fix map drag positions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -146,10 +146,20 @@ function App() {
       if (useRealData) {
         const googleMapsService = GoogleMapsService.getInstance();
         await googleMapsService.initialize();
-        const waypoints = stopsToUse.map(s => s.address);
+        const waypoints = stopsToUse.map(s =>
+          s.lat !== undefined && s.lng !== undefined
+            ? `${s.lat},${s.lng}`
+            : s.address
+        );
         const directionsResult = await googleMapsService.getRoutes({
-          origin: planningOrigin,
-          destination: planningDestination,
+          origin:
+            planningOriginCoords !== undefined
+              ? `${planningOriginCoords.lat},${planningOriginCoords.lng}`
+              : planningOrigin,
+          destination:
+            planningDestinationCoords !== undefined
+              ? `${planningDestinationCoords.lat},${planningDestinationCoords.lng}`
+              : planningDestination,
           waypoints
         });
         analyzedRoutes = directionsResult.routes.map((gRoute, index) => {


### PR DESCRIPTION
## Summary
- preserve drag positions for start, end, and stops when analyzing a route

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*
- `npm run build` *(fails: TypeScript errors about missing `google` types)*

------
https://chatgpt.com/codex/tasks/task_e_686854ecb79483238764e314e48be265