### PR TITLE
Fix map marker persistence and u‑turn detection

### DIFF
--- a/src/components/PlanningMapComponent.tsx
+++ b/src/components/PlanningMapComponent.tsx
@@ -157,6 +157,8 @@ export const PlanningMapComponent: React.FC<PlanningMapComponentProps> = ({
 
       if (originCoords) {
         originLocation = new google.maps.LatLng(originCoords.lat, originCoords.lng);
+      } else if (originMarker && originMarker.getPosition()) {
+        originLocation = originMarker.getPosition()!;
       } else {
         const originResults = await googleMapsService.geocodeAddress(origin);
         if (originResults.length === 0) {
@@ -167,6 +169,8 @@ export const PlanningMapComponent: React.FC<PlanningMapComponentProps> = ({
 
       if (destinationCoords) {
         destinationLocation = new google.maps.LatLng(destinationCoords.lat, destinationCoords.lng);
+      } else if (destinationMarker && destinationMarker.getPosition()) {
+        destinationLocation = destinationMarker.getPosition()!;
       } else {
         const destinationResults = await googleMapsService.geocodeAddress(destination);
         if (destinationResults.length === 0) {

--- a/src/services/googleMapsService.ts
+++ b/src/services/googleMapsService.ts
@@ -389,7 +389,7 @@ private filterRoutesByConstraints(routes: google.maps.DirectionsRoute[], constra
   return routes.filter(route => {
     for (const leg of route.legs) {
       for (const step of leg.steps) {
-        const instr = step.instructions.toLowerCase();
+        const instr = step.instructions.replace(/<[^>]*>/g, ' ').toLowerCase();
         const maneuver = (step as any).maneuver?.toLowerCase() || '';
         const hasUTurn =
           instr.includes('u-turn') ||


### PR DESCRIPTION
## Summary
- preserve moved marker coordinates when adding stops
- strip HTML from instructions to better detect U-turns

## Testing
- `npm run lint` *(fails: cannot find package `@eslint/js`)*

------
https://chatgpt.com/codex/tasks/task_e_686857b752348323bacea77901e1e76a