### PR TITLE
Default routes to loops and disable waypoint optimization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -45,7 +45,7 @@ function App() {
   const [lastAnalyzedDestination, setLastAnalyzedDestination] = useState('');
   const [stops, setStops] = useState<StopLocation[]>([]);
   const [initialCenter, setInitialCenter] = useState({ lat: 39.8283, lng: -98.5795 });
-  const [isLoop, setIsLoop] = useState(false);
+  const [isLoop, setIsLoop] = useState(true);
 
   const [planningOrigin, setPlanningOrigin] = useState('');
   const [planningDestination, setPlanningDestination] = useState('');
@@ -168,7 +168,7 @@ function App() {
           destination: finalDestination,
           waypoints,
           vehicle,
-          optimizeWaypoints: !isLoop
+          optimizeWaypoints: false
         });
         analyzedRoutes = directionsResult.routes.map((gRoute, index) => {
           const appRoute = transformGoogleRouteToAppRoute(gRoute, index, stopsToUse);
@@ -314,7 +314,7 @@ function App() {
         destination: finalDestination,
         waypoints,
         vehicle,
-        optimizeWaypoints: !useLoop
+        optimizeWaypoints: false
       });
       let analyzedRoutes = directionsResult.routes.map((gRoute, index) => {
         const appRoute = transformGoogleRouteToAppRoute(gRoute, index, stopsToUse);

--- a/src/components/PlanningMapComponent.tsx
+++ b/src/components/PlanningMapComponent.tsx
@@ -31,7 +31,7 @@ export const PlanningMapComponent: React.FC<PlanningMapComponentProps> = ({
   isReady = false,
   onMapUpdate,
   initialCenter = { lat: 30.2241, lng: -92.0198 }, // Default to Lafayette, LA
-  isLoop = false,
+  isLoop = true,
   originCoords,
   destinationCoords,
   showRoute = false

--- a/src/components/RouteInput.tsx
+++ b/src/components/RouteInput.tsx
@@ -23,7 +23,7 @@ export const RouteInput: React.FC<RouteInputProps> = ({
   initialDestination = '',
   stops = [], // Provide default empty array
   onStopsChange,
-  isLoop = false,
+  isLoop = true,
   onLoopChange
 }) => {
   // Keep local state persistent and sync with props properly
@@ -167,7 +167,7 @@ export const RouteInput: React.FC<RouteInputProps> = ({
   };
 
   const handleLoopChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const newIsLoop = e.target.checked;
+    const newIsLoop = !e.target.checked;
     setLocalIsLoop(newIsLoop);
     if (onLoopChange) {
       onLoopChange(newIsLoop);
@@ -293,14 +293,14 @@ export const RouteInput: React.FC<RouteInputProps> = ({
                 <div className="flex items-center">
                   <input
                     type="checkbox"
-                    id="loopRoute"
-                    checked={localIsLoop}
+                    id="disableLoop"
+                    checked={!localIsLoop}
                     onChange={handleLoopChange}
                     className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded dark:bg-gray-700 dark:border-gray-600"
                     disabled={isLoading || apiStatus !== 'ready'}
                   />
-                  <label htmlFor="loopRoute" className="ml-2 text-sm text-gray-900 dark:text-gray-200">
-                    Loop route (return to starting location)
+                  <label htmlFor="disableLoop" className="ml-2 text-sm text-gray-900 dark:text-gray-200">
+                    Disable loop route
                   </label>
                 </div>
                 


### PR DESCRIPTION
## Summary
- make loop routing the default
- rename loop toggle to `Disable loop route`
- disable waypoint optimization when requesting directions

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6868b2d7b45c8323bdaca19d83e15fa0